### PR TITLE
Links a múltiples repositorios en PP y ALG

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -292,6 +292,11 @@ export default defineConfig({
                     link: "https://github.com/migueldeoleiros/PP",
                     badge: { text: "GitHub", variant: "tip" },
                   },
+                  {
+                    label: "CValle_/gei2/PP",
+                    link: "https://gitlab.com/CValle_/gei2/-/tree/main/PP",
+                    badge: { text: "GitLab", variant: "tip" },
+                  },
                 ],
               },
             ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -298,6 +298,7 @@ export default defineConfig({
               {
                 label: "Apuntes",
                 autogenerate: { directory: "pepe/apuntes" },
+                badge: { text: "WIP", variant: "caution" },
               },
               {
                 label: "Código en OCamel",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -236,8 +236,38 @@ export default defineConfig({
             label: "Algoritmos",
             link: "/algo/",
             icon: "seti:clock",
-            items: [],
-            badge: { text: "WIP", variant: "danger" },
+            items: [
+              {
+                label: "Implementaciones",
+                autogenerate: { directory: "algo/implementaciones" },
+                badge: { text: "WIP", variant: "caution" },
+              },
+              {
+                label: "Prácticas y Exámenes",
+                items: [
+                  {
+                    label: "migueldeoleiros/examen-algoritmos",
+                    link: "https://github.com/migueldeoleiros/examen-algoritmos",
+                    badge: { text: "GitHub", variant: "tip" },
+                  },
+                  {
+                    label: "migueldeoleiros/Algoritmos",
+                    link: "https://github.com/migueldeoleiros/Algoritmos",
+                    badge: { text: "GitHub", variant: "tip" },
+                  },
+                  {
+                    label: "JavierFreireBouzas/Algoritmos-FIC-UDC",
+                    link: "https://github.com/JavierFreireBouzas/Algoritmos-FIC-UDC",
+                    badge: { text: "GitHub", variant: "tip" },
+                  },
+                  {
+                    label: "CValle_/gei2/Algo",
+                    link: "https://gitlab.com/CValle_/gei2/-/tree/main/Algo",
+                    badge: { text: "GitLab", variant: "tip" },
+                  },
+                ],
+              },
+            ],
           },
           {
             label: "Diseño de Software",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -282,6 +282,16 @@ export default defineConfig({
                     link: "https://github.com/TeenBiscuits/Practicas-PP",
                     badge: { text: "GitHub", variant: "tip" },
                   },
+                  {
+                    label: "antonlnz/PP",
+                    link: "https://github.com/antonlnz/PP",
+                    badge: { text: "GitHub", variant: "tip" },
+                  },
+                  {
+                    label: "migueldeoleiros/PP",
+                    link: "https://github.com/migueldeoleiros/PP",
+                    badge: { text: "GitHub", variant: "tip" },
+                  },
                 ],
               },
             ],

--- a/src/content/docs/algo/index.mdx
+++ b/src/content/docs/algo/index.mdx
@@ -7,22 +7,38 @@ prev:
 tableOfContents: false
 ---
 
+import { LinkCard } from '@astrojs/starlight/components';
+
 > Implementaciones y pseudocódigos de todos los algoritmos y de las estructuras de datos. Links a prácticas resueltas.
 
-import { Aside, LinkButton } from '@astrojs/starlight/components';
+## Implementaciones :badge[WIP]{variant=caution}
 
-<Aside type="caution">Seguimos en obras por aquí. 🏗️</Aside>
+<LinkCard
+  title="En Construcción 👷"
+  href="/pepe"
+  description="¡Estamos estudiando!"
+/>
 
-<Aside type="tip">
+# Prácticas y Exámenes
 
-Ven a ayudarnos a construir esta página. 👷‍♂️👷‍♀️
+<LinkCard
+  title="migueldeoleiros/examen-algoritmos"
+  href="https://github.com/migueldeoleiros/examen-algoritmos"
+  description="Ejemplos de las posibles variaciones de las prácticas de la asigatura de Algoritmos de la Universidad De A Coruña en el grado de ingeniería informática de 2021/2022. Con el objetivo de hacer todos los posibles exámenes."
+/>
+<LinkCard
+  title="migueldeoleiros/Algoritmos"
+  href="https://github.com/migueldeoleiros/Algoritmos"
+  description="Prácticas de la asignatura de Algoritmos de la Universidad De A Coruña (UDC) en el grado de ingeniería informática curso 2021/2022 GEI-Algo 614G010112122"
+/>
+<LinkCard
+  title="JavierFreireBouzas/Algoritmos-FIC-UDC"
+  href="https://github.com/JavierFreireBouzas/Algoritmos-FIC-UDC"
+  description='Prácticas de Algoritmos | Code generated during the "Algoritmos" subject (Universidade da Coruña)'
+/>
+<LinkCard
+  title="CValle_/gei2/Algo"
+  href="https://gitlab.com/CValle_/gei2/-/tree/main/Algo"
+  description="Apuntes y Prácticas de Clara Valle | Notes for my second year of university at UDC"
+/>
 
-<LinkButton href="https://github.com/TeenBiscuits/Pasame-Codigo" variant="secondary" icon="github">
-  ¡Contribuye!
-</LinkButton>
-
-<LinkButton href="/" variant="secondary" icon="right-arrow">
-  Volver al inicio
-</LinkButton>
-
-</Aside>

--- a/src/content/docs/algo/index.mdx
+++ b/src/content/docs/algo/index.mdx
@@ -15,7 +15,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 <LinkCard
   title="En Construcción 👷"
-  href="/pepe"
+  href="/algo"
   description="¡Estamos estudiando!"
 />
 

--- a/src/content/docs/pepe/index.mdx
+++ b/src/content/docs/pepe/index.mdx
@@ -31,3 +31,13 @@ import { LinkCard } from '@astrojs/starlight/components';
   href="https://github.com/TeenBiscuits/Practicas-PP"
   description="Prácticas de la asignatura Paradigmas de la Programación en OCaml. No es mucho, pero es trabajo honesto"
 />
+<LinkCard
+  title="antonlnz/PP"
+  href="https://github.com/antonlnz/PP"
+  description="Práctica de la asignatura de Paradigmas de Programación de la Universidad De A Coruña (UDC) en el grado de ingeniería informática curso 2021/2022 GEI-PP 614G010142122"
+/>
+<LinkCard
+  title="migueldeoleiros/PP"
+  href="https://github.com/migueldeoleiros/PP"
+  description="Práctica de la asignatura de Paradigmas de Programación de la Universidad De A Coruña (UDC) en el grado de ingeniería informática curso 2021/2022 GEI-PP 614G010142122"
+/>

--- a/src/content/docs/pepe/index.mdx
+++ b/src/content/docs/pepe/index.mdx
@@ -41,3 +41,8 @@ import { LinkCard } from '@astrojs/starlight/components';
   href="https://github.com/migueldeoleiros/PP"
   description="Práctica de la asignatura de Paradigmas de Programación de la Universidad De A Coruña (UDC) en el grado de ingeniería informática curso 2021/2022 GEI-PP 614G010142122"
 />
+<LinkCard
+  title="CValle_/gei2/PP"
+  href="https://gitlab.com/CValle_/gei2/-/tree/main/PP"
+  description="Apuntes, entregas y exámenes de Clara Valle | Notes for my second year of university at UDC"
+/>


### PR DESCRIPTION
This pull request includes several updates to the `astro.config.mjs` configuration file and documentation files to add new links and badges for various resources related to algorithms and programming paradigms. The changes introduce new sections and update existing ones to provide more comprehensive resources.

Configuration updates:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL239-R270): Added new items under the "Algoritmos" section, including links to implementations, practices, and exams with appropriate badges.
* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR301): Added a "WIP" badge to the "Apuntes" section under the "pepe" directory.
* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR316-R330): Added new links under the "Prácticas y Exámenes" section for the "PP" directory with GitHub and GitLab badges.

Documentation updates:

* [`src/content/docs/algo/index.mdx`](diffhunk://#diff-39808452dd3240485fec07bda15cc956ce02dad543820960b48d547d68bc419cL10-L28): Replaced the cautionary aside with `LinkCard` components for various algorithm resources, including GitHub and GitLab links.
* [`src/content/docs/pepe/index.mdx`](diffhunk://#diff-a43732747d8d5ed2c346104ee7d3bb6b3f185abce54c098861ffb56596b13c65R34-R48): Added new `LinkCard` components for additional Paradigmas de Programación resources.